### PR TITLE
Extend manifest properties

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add more manifest property keys: Plugin-Link, Plugin-Category, Created-By, and Plugin-Date
+
+### Changed
+- Signature of OmegatManifest constructor.
+
+
 ## [1.4.1] - 2021-01-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ To apply the plugin, please add one of the following snippets to your `build.gra
 
 ```groovy
 plugins {
-    id 'org.omegat.gradle' version '1.4.0'
+    id 'org.omegat.gradle' version '1.4.2'
 }
 ```
 or `build.gradle.kts` in Kotlin;
 
 ```kotlin
 plugins {
-    id("org.omegat.gradle") version "1.4.0"
+    id("org.omegat.gradle") version "1.4.2"
 }
 ```
 
@@ -67,13 +67,13 @@ To apply the plugin, please add one of the following snippets to your `build.gra
 
 ```groovy
 plugins {
-    id 'org.omegat.gradle' version '1.4.0'
+    id 'org.omegat.gradle' version '1.4.2'
 }
 ```
 or in kotlin
 ```kotlin
 plugins {
-    id("org.omegat.gralde") version "1.4.0"
+    id("org.omegat.gralde") version "1.4.2"
 }
 ```
 
@@ -145,9 +145,9 @@ Here is a table how properties becomes manifest record;
 | Description | Plugin-Description | `plugin.description` | n/a         |
 | Website     | Plugin-Link | `plugin.link`  | n/a                      |
 | Category | Plugin-Category | `plugin.category` | n/a                  |
-| Built environment | Created-By | n/a  | n/a                             |
+| Built environment | Created-By | n/a  | n/a                           |
 | Date | Plugin-Date | n/a  | n/a                                       |
-| Class name | OmegaT-Plugins | n/a  | n/a                               | 
+| Class name | OmegaT-Plugins | n/a  | n/a                              |
 
 Plugin Name can be configured with `plugin.name` property. When it is not set,
 `rootProject.name` gradle property that is configured in `settings.gradle` is used.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ and open OmegaT project at configured as `omegat.projectDir`
 You can put dependencies with packIntoJar configuration, dependencies are bundled with plugin as Fat-Jar.
 Libraries other than packIntoJar such as implementation, compile etc. are used to compile but not bundled.
 A following example illustrate how to use, and slf4j-api is going to be bundled, and commons-io library is not.
-It is because commons-io is dependency of OmegaT, so we can use it without bundled.
+It is because commons-io is a dependency of OmegaT, so we can use it without bundled.
 
 ```groovy
 dependencies {
@@ -139,8 +139,19 @@ Here is a table how properties becomes manifest record;
 
 | Data | plugin manifest | gradle.properties | gradle standard property |
 | ---- | --------------- | ----------------- | ------------------------ |
-| Name | Plugin-Name     | n/a               | rootProject.name         |
+| Name | Plugin-Name     | `plugin.name`     | rootProject.name         |
 | Version | Plugin-Version | n/a             | version                  |
 | Author | Plugin-Author | `plugin.author`   | n/a                      |
 | Description | Plugin-Description | `plugin.description` | n/a         |
 | Website     | Plugin-Link | `plugin.link`  | n/a                      |
+| Category | Plugin-Category | `plugin.category` | n/a                  |
+| Built environment | Built-By | n/a  | n/a                             |
+| Date | Plugin-Date | n/a  | n/a                                       |
+| Class name | OmegaT-Plugins | n/a  | n/a                               | 
+
+Plugin Name can be configured with `plugin.name` property. When it is not set,
+`rootProject.name` gradle property that is configured in `settings.gradle` is used.
+When both properties are not set, project directory name is used as
+same as ordinary gradle projects.
+Built environment and date records are automatically added to manifest.
+Class name is configured by extension `omegat.pluginClass` in `build.gradle`.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Here is a table how properties becomes manifest record;
 | Description | Plugin-Description | `plugin.description` | n/a         |
 | Website     | Plugin-Link | `plugin.link`  | n/a                      |
 | Category | Plugin-Category | `plugin.category` | n/a                  |
-| Built environment | Built-By | n/a  | n/a                             |
+| Built environment | Created-By | n/a  | n/a                             |
 | Date | Plugin-Date | n/a  | n/a                                       |
 | Class name | OmegaT-Plugins | n/a  | n/a                               | 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `maven-publish`
 }
 group = "org.omegat"
-version = "1.4.1"
+version = "1.4.2-SNAPSHOT"
 
 tasks.compileJava {
     options.release.set(8)

--- a/src/main/kotlin/org/omegat/gradle/Setup.kt
+++ b/src/main/kotlin/org/omegat/gradle/Setup.kt
@@ -30,7 +30,7 @@ fun Project.setupOmegatTasks(extension: PluginExtension) {
             jarTask.outputs.upToDateWhen { false }
             jarTask.doFirst { task ->
                 if (extension.pluginClass != null) {
-                    jarTask.manifest.attributes(extension.manifest.createOmegatPluginJarManifest())
+                    jarTask.manifest.attributes(extension.manifest.createOmegatPluginJarManifest(extension))
                 }
                 jarTask.from(
                     task.project.configurations.getByName("packIntoJar").files.map { file ->

--- a/src/main/kotlin/org/omegat/gradle/config/DefaultModule.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/DefaultModule.kt
@@ -2,7 +2,7 @@ package org.omegat.gradle.config
 
 import org.gradle.api.Project
 import org.omegat.gradle.OmegatPlugin
-import java.util.*
+import java.util.Properties
 
 class DefaultModule(val project: Project) {
     private val props = Properties()

--- a/src/main/kotlin/org/omegat/gradle/config/DefaultModule.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/DefaultModule.kt
@@ -11,8 +11,8 @@ class DefaultModule(val project: Project) {
         props.load(OmegatPlugin::class.java.getResourceAsStream("omegat.properties"))
         project.repositories.jcenter()
         project.repositories.apply {
-            maven {
-                it.setUrl(props.getProperty("mavenRepositoryUrl"))
+            maven { artifactRepository ->
+                artifactRepository.setUrl(props.getProperty("mavenRepositoryUrl"))
             }
         }
     }

--- a/src/main/kotlin/org/omegat/gradle/config/OmegatManifest.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/OmegatManifest.kt
@@ -2,6 +2,8 @@ package org.omegat.gradle.config
 
 import org.gradle.api.Project
 import java.net.URL
+import java.util.GregorianCalendar
+
 
 class OmegatManifest(private val project: Project, private val extension: PluginExtension) {
 
@@ -12,10 +14,15 @@ class OmegatManifest(private val project: Project, private val extension: Plugin
         const val PLUGIN_DESCRIPTION = "Plugin-Description"
         const val PLUGIN_MAIN_CLASS = "OmegaT-Plugins"
         const val PLUGIN_WEBSITE = "Plugin-Link"
+        const val PLUGIN_CATEGORY = "Plugin-Category"
+        const val PLUGIN_DATE = "Plugin-Date"
+        const val CREATED_BY = "Created-By"
     }
 
+    var name: String? = project.findProperty("plugin.name")?.toString()
     var author: String? = project.findProperty("plugin.author")?.toString()
     var description: String? = project.findProperty("plugin.description")?.toString()
+    var category: String? = project.findProperty("plugin.category")?.toString()
     var website: URL? =
         if (project.hasProperty("plugin.link"))
             URL(project.findProperty("plugin.link").toString().removeSurrounding("\""))
@@ -24,12 +31,15 @@ class OmegatManifest(private val project: Project, private val extension: Plugin
     fun createOmegatPluginJarManifest(): Map<String, String> {
 
         val manifestAtts: MutableMap<String,String?> = mutableMapOf(
-            Attribute.PLUGIN_NAME to extension.pluginName,
+            Attribute.PLUGIN_NAME to if (name != null) name else extension.pluginName,
             Attribute.PLUGIN_AUTHOR to author,
             Attribute.PLUGIN_MAIN_CLASS to extension.pluginClass,
             Attribute.PLUGIN_DESCRIPTION to description,
             Attribute.PLUGIN_VERSION to project.version.toString(),
-        Attribute.PLUGIN_WEBSITE to website?.toString()
+            Attribute.PLUGIN_WEBSITE to website?.toString(),
+            Attribute.PLUGIN_CATEGORY to category,
+            Attribute.CREATED_BY to "${System.getProperty("java.version")} (${System.getProperty("java.vendor")})",
+            Attribute.PLUGIN_DATE to String.format("%1\$tY-%1\$tm-%1\$tdT%1\$tH:%1\$tM:%1\$tS%1\$tz", GregorianCalendar())
         )
         return manifestAtts.mapNotNull { entry ->
           entry.value?.let { Pair(entry.key, it) } // only return entries with not-null value

--- a/src/main/kotlin/org/omegat/gradle/config/OmegatManifest.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/OmegatManifest.kt
@@ -5,7 +5,7 @@ import java.net.URL
 import java.util.GregorianCalendar
 
 
-class OmegatManifest(private val project: Project, private val extension: PluginExtension) {
+class OmegatManifest(private val project: Project) {
 
     object Attribute {
         const val PLUGIN_NAME = "Plugin-Name"
@@ -28,7 +28,7 @@ class OmegatManifest(private val project: Project, private val extension: Plugin
             URL(project.findProperty("plugin.link").toString().removeSurrounding("\""))
         else null
 
-    fun createOmegatPluginJarManifest(): Map<String, String> {
+    fun createOmegatPluginJarManifest(extension: PluginExtension): Map<String, String> {
 
         val manifestAtts: MutableMap<String,String?> = mutableMapOf(
             Attribute.PLUGIN_NAME to if (name != null) name else extension.pluginName,

--- a/src/main/kotlin/org/omegat/gradle/config/PluginExtension.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/PluginExtension.kt
@@ -17,7 +17,7 @@ open class PluginExtension(val project: Project) {
     var pluginClass: String? = null
     var debugPort: Int? = null
 
-    val manifest: OmegatManifest = OmegatManifest(project, this)
+    val manifest: OmegatManifest = OmegatManifest(project)
 
     /**
      * Set the [packIntoJarFileFilter] with a Groovy [Closure]


### PR DESCRIPTION
Extend manifest properties.

| Data | plugin manifest | gradle.properties | gradle standard property |
| ---- | --------------- | ----------------- | ------------------------ |
| Website     | Plugin-Link | `plugin.link`  | n/a                      |
| Category | Plugin-Category | `plugin.category` | n/a                  |
| Built environment | Built-By | n/a  | n/a                             |
| Date | Plugin-Date | n/a  | n/a                                       |


Property extension is discussed at [RFE#1544](https://sourceforge.net/p/omegat/feature-requests/1544/) which  just propose website but the PR also propose others.
Also fixed #7
