### PR TITLE
Make plugin.name property mandatory

### DIFF
--- a/src/main/kotlin/org/omegat/gradle/Setup.kt
+++ b/src/main/kotlin/org/omegat/gradle/Setup.kt
@@ -29,8 +29,12 @@ fun Project.setupOmegatTasks(extension: PluginExtension) {
             }
             jarTask.outputs.upToDateWhen { false }
             jarTask.doFirst { task ->
-                if (extension.pluginClass != null) {
-                    jarTask.manifest.attributes(extension.manifest.createOmegatPluginJarManifest(extension))
+                val pluginName = project.findProperty("plugin.name")
+                if (extension.pluginClass != null && pluginName != null) {
+                    val className: String = extension.pluginClass.toString()
+                    jarTask.manifest.attributes(
+                        extension.manifest.createOmegatPluginJarManifest(className, pluginName.toString())
+                    )
                 }
                 jarTask.from(
                     task.project.configurations.getByName("packIntoJar").files.map { file ->

--- a/src/main/kotlin/org/omegat/gradle/config/OmegatManifest.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/OmegatManifest.kt
@@ -19,7 +19,6 @@ class OmegatManifest(private val project: Project) {
         const val CREATED_BY = "Created-By"
     }
 
-    var name: String? = project.findProperty("plugin.name")?.toString()
     var author: String? = project.findProperty("plugin.author")?.toString()
     var description: String? = project.findProperty("plugin.description")?.toString()
     var category: String? = project.findProperty("plugin.category")?.toString()
@@ -28,12 +27,11 @@ class OmegatManifest(private val project: Project) {
             URL(project.findProperty("plugin.link").toString().removeSurrounding("\""))
         else null
 
-    fun createOmegatPluginJarManifest(extension: PluginExtension): Map<String, String> {
-
+    fun createOmegatPluginJarManifest(pluginClass: String, pluginName: String): Map<String, String> {
         val manifestAtts: MutableMap<String,String?> = mutableMapOf(
-            Attribute.PLUGIN_NAME to if (name != null) name else extension.pluginName,
+            Attribute.PLUGIN_NAME to pluginName,
+            Attribute.PLUGIN_MAIN_CLASS to pluginClass,
             Attribute.PLUGIN_AUTHOR to author,
-            Attribute.PLUGIN_MAIN_CLASS to extension.pluginClass,
             Attribute.PLUGIN_DESCRIPTION to description,
             Attribute.PLUGIN_VERSION to project.version.toString(),
             Attribute.PLUGIN_WEBSITE to website?.toString(),

--- a/src/main/kotlin/org/omegat/gradle/config/PluginExtension.kt
+++ b/src/main/kotlin/org/omegat/gradle/config/PluginExtension.kt
@@ -6,7 +6,6 @@ import org.gradle.api.tasks.util.PatternFilterable
 
 
 open class PluginExtension(project: Project) {
-    var pluginName: String? = null
     var projectDir: String? = null
     var version: String? = null
     var pluginClass: String? = null


### PR DESCRIPTION
- Drop extension `pluginName` property
- Enable plugin development function when plugin.name gradle property and pluginClass extension property specified

Signed-off-by: Hiroshi Miura <miurahr@linux.com>